### PR TITLE
docker environments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.cache
+Docker/
+*.md
+build_docker.sh

--- a/Docker/parallel.dockerfile
+++ b/Docker/parallel.dockerfile
@@ -1,0 +1,88 @@
+FROM ubuntu:focal as xyce_build
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt install -y git cmake build-essential gcc g++ ninja-build gfortran make bison flex libfl-dev libfftw3-dev libsuitesparse-dev libblas-dev liblapack-dev libtool autoconf automake libopenmpi-dev openmpi-bin
+
+RUN git clone --branch Release-7.4.0   --depth 1 https://github.com/Xyce/Xyce.git
+
+RUN git clone --branch trilinos-release-12-12-1 --depth 1 https://github.com/trilinos/Trilinos.git
+
+WORKDIR /Trilinos
+
+RUN mkdir build && cd build && cmake -GNinja -DCMAKE_C_COMPILER=mpicc \
+-DCMAKE_CXX_COMPILER=mpic++ \
+-DCMAKE_Fortran_COMPILER=mpif77 \
+-DCMAKE_CXX_FLAGS="-O3 -fPIC" \
+-DCMAKE_C_FLAGS="-O3 -fPIC" \
+-DCMAKE_Fortran_FLAGS="-O3 -fPIC" \
+-DCMAKE_MAKE_PROGRAM="ninja" \
+-DCMAKE_INSTALL_PREFIX="/opt/trilinos_parallel" \
+-DTrilinos_ENABLE_NOX=ON \
+-DNOX_ENABLE_LOCA=ON \
+-DTrilinos_ENABLE_EpetraExt=ON \
+-DEpetraExt_BUILD_BTF=ON \
+-DEpetraExt_BUILD_EXPERIMENTAL=ON \
+-DEpetraExt_BUILD_GRAPH_REORDERINGS=ON \
+-DTrilinos_ENABLE_TrilinosCouplings=ON \
+-DTrilinos_ENABLE_Ifpack=ON \
+-DTrilinos_ENABLE_Isorropia=ON \
+-DTrilinos_ENABLE_AztecOO=ON \
+-DTrilinos_ENABLE_Belos=ON \
+-DTrilinos_ENABLE_Teuchos=ON \
+-DTrilinos_ENABLE_COMPLEX_DOUBLE=ON \
+-DTrilinos_ENABLE_Amesos=ON \
+-DAmesos_ENABLE_KLU=ON \
+-DTrilinos_ENABLE_Amesos2=ON \
+-DAmesos2_ENABLE_KLU2=ON \
+-DAmesos2_ENABLE_Basker=ON \
+-DTrilinos_ENABLE_Sacado=ON \
+-DTrilinos_ENABLE_Stokhos=ON \
+-DTrilinos_ENABLE_Kokkos=ON \
+-DTrilinos_ENABLE_Zoltan=ON \
+-DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF \
+-DTrilinos_ENABLE_CXX11=ON \
+-DTPL_ENABLE_AMD=ON \
+-DAMD_LIBRARY_DIRS="/usr/lib" \
+-DTPL_AMD_INCLUDE_DIRS="/usr/include/suitesparse" \
+-DTPL_ENABLE_BLAS=ON \
+-DTPL_ENABLE_LAPACK=ON \
+-DTPL_ENABLE_MPI=ON ..
+
+RUN cd build && cmake --build . && ninja install
+
+WORKDIR /Xyce
+
+RUN ./bootstrap && mkdir build && cd build && \
+ ../configure CXXFLAGS="-O3" ARCHDIR="/opt/trilinos_parallel" CPPFLAGS="-I/usr/include/suitesparse" -enable-mpi \
+CXX=mpicxx \
+CC=mpicc \
+F77=mpif77 \
+--enable-stokhos \
+--enable-amesos2 \
+--prefix=/opt/XyceInstall/Parallel && \ 
+make -j $(nproc) && make install
+
+FROM ubuntu:focal
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt install -y nano vim python-is-python3 python3-pip gfortran bison flex libfl-dev libfftw3-dev libsuitesparse-dev libblas-dev liblapack-dev libtool libopenmpi-dev openmpi-bin
+WORKDIR /
+COPY --from=xyce_build /opt /opt
+
+ENV PATH /opt/XyceInstall/Parallel/bin:$PATH
+
+RUN useradd -ms /bin/bash pact
+
+WORKDIR /home/pact
+
+COPY ./requirements.txt requirements.txt
+
+USER pact
+
+RUN pip3 install -r requirements.txt
+
+COPY --chown=pact:pact . ./
+
+CMD ["/bin/bash"]

--- a/Docker/serial.dockerfile
+++ b/Docker/serial.dockerfile
@@ -1,0 +1,80 @@
+FROM ubuntu:focal as xyce_build
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt install -y gcc g++ build-essential ninja-build gfortran make cmake bison flex libfl-dev libfftw3-dev libsuitesparse-dev libblas-dev liblapack-dev libtool automake autoconf
+
+RUN git clone --branch Release-7.4.0   --depth 1 https://github.com/Xyce/Xyce.git
+
+RUN git clone --branch trilinos-release-12-12-1 --depth 1 https://github.com/trilinos/Trilinos.git
+
+WORKDIR /Trilinos
+
+ARG FLAGS="-O3 -fPIC"
+
+RUN mkdir build && cd build && cmake -GNinja \
+-DCMAKE_C_COMPILER=gcc \
+-DCMAKE_CXX_COMPILER=g++ \
+-DCMAKE_Fortran_COMPILER=gfortran \
+-DCMAKE_CXX_FLAGS="$FLAGS" \
+-DCMAKE_C_FLAGS="$FLAGS" \
+-DCMAKE_Fortran_FLAGS="$FLAGS" \
+-DCMAKE_INSTALL_PREFIX="/opt/trilinos_serial" \
+-DCMAKE_MAKE_PROGRAM="ninja" \
+-DTrilinos_ENABLE_NOX=ON \
+  -DNOX_ENABLE_LOCA=ON \
+-DTrilinos_ENABLE_EpetraExt=ON \
+  -DEpetraExt_BUILD_BTF=ON \
+  -DEpetraExt_BUILD_EXPERIMENTAL=ON \
+  -DEpetraExt_BUILD_GRAPH_REORDERINGS=ON \
+-DTrilinos_ENABLE_TrilinosCouplings=ON \
+-DTrilinos_ENABLE_Ifpack=ON \
+-DTrilinos_ENABLE_Isorropia=ON \
+-DTrilinos_ENABLE_AztecOO=ON \
+-DTrilinos_ENABLE_Belos=ON \
+-DTrilinos_ENABLE_Teuchos=ON \
+  -DTeuchos_ENABLE_COMPLEX=ON \
+-DTrilinos_ENABLE_Amesos=ON \
+  -DAmesos_ENABLE_KLU=ON \
+-DTrilinos_ENABLE_Sacado=ON \
+-DTrilinos_ENABLE_Kokkos=OFF \
+-DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF \
+-DTrilinos_ENABLE_CXX11=OFF \
+-DTPL_ENABLE_AMD=ON \
+-DAMD_LIBRARY_DIRS="/usr/lib" \
+-DTPL_AMD_INCLUDE_DIRS="/usr/include/suitesparse" \
+-DTPL_ENABLE_BLAS=ON \
+-DTPL_ENABLE_LAPACK=ON ..
+
+RUN cd build && cmake --build . && ninja install
+
+WORKDIR /Xyce
+
+RUN ./bootstrap && mkdir build && cd build && \
+ ../configure CXXFLAGS="-O3" ARCHDIR="/opt/trilinos_serial" CPPFLAGS="-I/usr/include/suitesparse" \
+--prefix=/opt/XyceInstall/Serial && \ 
+make -j $(nproc) && make install
+
+FROM ubuntu:focal
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt install -y nano vim python-is-python3 python3-pip gfortran bison flex libfl-dev libfftw3-dev libsuitesparse-dev libblas-dev liblapack-dev libtool
+WORKDIR /
+COPY --from=xyce_build /opt /opt
+
+ENV PATH /opt/XyceInstall/Parallel/bin:$PATH
+
+RUN useradd -ms /bin/bash pact
+
+WORKDIR /home/pact
+
+COPY ./requirements.txt requirements.txt
+
+USER pact
+
+RUN pip3 install -r requirements.txt
+
+COPY --chown=pact:pact . ./
+
+CMD ["/bin/bash"]

--- a/Docker/serial.dockerfile
+++ b/Docker/serial.dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:focal as xyce_build
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && apt install -y gcc g++ build-essential ninja-build gfortran make cmake bison flex libfl-dev libfftw3-dev libsuitesparse-dev libblas-dev liblapack-dev libtool automake autoconf
+RUN apt update && apt install -y gcc g++ git build-essential ninja-build gfortran make cmake bison flex libfl-dev libfftw3-dev libsuitesparse-dev libblas-dev liblapack-dev libtool automake autoconf
 
 RUN git clone --branch Release-7.4.0   --depth 1 https://github.com/Xyce/Xyce.git
 

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -l
+
+docker build --pull --rm -f "Docker\parallel.dockerfile" -t pact:latest-parallel .
+docker build --pull --rm -f "Docker\serial.dockerfile" -t pact:latest-serial .

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,4 +1,7 @@
 #!/bin/sh -l
 
-docker build --pull --rm -f "Docker\parallel.dockerfile" -t pact:latest-parallel .
+#docker build --pull --rm -f "Docker\parallel.dockerfile" -t pact:latest-parallel .   <-- not currently working
+
+###TODO: check if models are already downloaded before building docker image, get them if not
+
 docker build --pull --rm -f "Docker\serial.dockerfile" -t pact:latest-serial .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.14.5
-pandas==0.23.3
-scipy==1.1.0
+numpy==1.22.0
+pandas==1.4.3
+scipy==1.8.1
 configparser==3.5.0


### PR DESCRIPTION
add both a parallel and serial docker image for portability and simplified dependency installation.

note: mpi doesnt seem to be playing nice, so for now only the serial docker image can run the example scripts documented.

usage: 
- download the model files with `python DownloadML.py`
- run `build_docker.sh` to generate the docker image, automatically tagged as `pact:latest-serial`
- the container can be run as an interactive shell with: `docker run -it --rm pact:latest-serial`
- if host machine files are needed they can be mounted with `-v`. eg: ` docker run -it --rm -v  SRC:DEST -u $(id -u ${USER}):$(id -g ${USER})  pact:latest-serial `
     - Note that this makes the internal filesystem, except for the mounted directory read only.

